### PR TITLE
Address issues 2 and 3

### DIFF
--- a/src/AI-DataFrameInspector/AISpDataFrameAbstractPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameAbstractPresenter.class.st
@@ -33,10 +33,12 @@ AISpDataFrameAbstractPresenter >> contextMenu [
 { #category : #initialization }
 AISpDataFrameAbstractPresenter >> contextMenuActions [
 
+	self halt. "2"
 	^ CmCommandGroup forSpec
 		beRoot;
 		register: (AISpDataFrameCopyRowValuesCommand forSpecContext: self);
 		register: (AISpDataFrameCopyRowValuesWithLabelsCommand forSpecContext: self);
+		register: (AISpDataFrameCopyRowSelectionsCommand forSpecContext: self);
 		yourself
 ]
 

--- a/src/AI-DataFrameInspector/AISpDataFrameBasicInfo.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameBasicInfo.class.st
@@ -49,6 +49,7 @@ AISpDataFrameBasicInfo >> initializePresenters [
 
 	dataFramePresenter := self newTable
 		showColumnHeaders;
+		beMultipleSelection;
 "		contextMenu: [ self contextMenu ];
 		contextKeyBindings: self contextMenuKeyBindings;"
 		items: self summaryDescriptionsLabels;

--- a/src/AI-DataFrameInspector/AISpDataFrameBasicViz.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameBasicViz.class.st
@@ -158,9 +158,9 @@ AISpDataFrameBasicViz >> plotAllHistograms: aCanvas [
 		self plotHistogram: columnAssoc ].
 	aCanvas addAll: shapes;
 		addInteraction: RSCanvasController new;
-		addInteraction: RSZoomToFitCanvasInteraction new;
-		addInteraction: RSZoomableCanvasInteraction new;
-		addInteraction: RSKeyNavigationCanvasInteraction new.
+		addInteraction: RSZoomToFitCanvas new;
+		addInteraction: RSZoomableCanvas new;
+		addInteraction: RSKeyNavigationCanvas new.
 	RSHorizontalLineLayout new
 		gapSize: 4;
 		on: shapes.

--- a/src/AI-DataFrameInspector/AISpDataFrameCommand.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameCommand.class.st
@@ -24,3 +24,10 @@ AISpDataFrameCommand >> selectedItem [
 
 	^ self context dataFramePresenter selectedItem
 ]
+
+{ #category : #accessing }
+AISpDataFrameCommand >> selectedItems [
+	" Answer a <Collection> with the checked items in the receiver's presenter context "
+
+	^ self context selectedItems
+]

--- a/src/AI-DataFrameInspector/AISpDataFrameCopyRowSelectionsCommand.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameCopyRowSelectionsCommand.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #AISpDataFrameCopyRowSelectionsCommand,
+	#superclass : #AISpDataFrameCommand,
+	#category : #'AI-DataFrameInspector'
+}
+
+{ #category : #converting }
+AISpDataFrameCopyRowSelectionsCommand >> asSpecCommand [ 
+	
+	^ super asSpecCommand 
+		iconProvider: self application;
+		iconName: #smallCopy;
+		shortcutKey: $s control unix | $s control win | $s command mac;
+		yourself
+]
+
+{ #category : #executing }
+AISpDataFrameCopyRowSelectionsCommand >> execute [
+	"Execute the actions that should be done by the command.
+	 This method expect that the context has been put in #context inst. var. if any context is relevant."
+
+	Clipboard clipboardText: self selectedItems storeString
+]
+
+{ #category : #initialization }
+AISpDataFrameCopyRowSelectionsCommand >> initialize [
+	super initialize.
+	self
+		name: 'Copy selected rows';
+		description: 'Copy selected rows to clipboard.'
+]

--- a/src/AI-DataFrameInspector/AISpDataFrameInspector.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameInspector.class.st
@@ -88,6 +88,7 @@ AISpDataFrameInspector >> contextMenuActions [
 		beRoot;
 		register: (AISpDataFrameCopyRowValuesCommand forSpecContext: self);
 		register: (AISpDataFrameCopyRowValuesWithLabelsCommand forSpecContext: self);
+		register: (AISpDataFrameCopyRowSelectionsCommand forSpecContext: self);
 		yourself
 ]
 
@@ -141,13 +142,13 @@ AISpDataFrameInspector >> initialize [
 ]
 
 { #category : #initialization }
-AISpDataFrameInspector >> initializeAdditionalInfoPane [
+AISpDataFrameInspector >> initializeAdditionalInfoPresenter [
 
 	additionalInfoPane := self instantiate: AISpDataFrameBasicPresenter on: self dataFrame.
 ]
 
 { #category : #initialization }
-AISpDataFrameInspector >> initializeDataFramePane [
+AISpDataFrameInspector >> initializeDataFramePresenter [
 
 	dataFramePresenter := self newTable
 		enableSearch;
@@ -173,9 +174,9 @@ AISpDataFrameInspector >> initializeEvaluatorPresenter [
 { #category : #initialization }
 AISpDataFrameInspector >> initializePresenters [
 
-	self initializeDataFramePane.
+	self initializeDataFramePresenter.
 	self initializeEvaluatorPresenter.
-	self initializeAdditionalInfoPane.
+	self initializeAdditionalInfoPresenter.
 	self initializeSummaryPresenter.
 
 ]

--- a/src/AI-DataFrameInspector/AISpDataFrameSummaryPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameSummaryPresenter.class.st
@@ -34,6 +34,7 @@ AISpDataFrameSummaryPresenter >> initializePresenter [
 
 	dataFramePresenter := self newTable
 		showColumnHeaders;
+		beMultipleSelection;
 "		contextMenu: [ self contextMenu ];
 		contextKeyBindings: self contextMenuKeyBindings;"
 		items: self summaryStatsLabels;


### PR DESCRIPTION
Class names were updated in Roassal3 latest version in Pharo 9. Update the names.

An option is missing to copy multiple checked items in the data frame inspector.
Add an item in the contextual menu to copy them to clipboard as storeString format.
