### PR TITLE
Add rownames data description

### DIFF
--- a/src/AI-DataFrameInspector/AISpAbstractVisualizerPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpAbstractVisualizerPresenter.class.st
@@ -60,20 +60,23 @@ AISpAbstractVisualizerPresenter >> plotAllHistograms: aCanvas [
 
 	| shapes |
 	shapes := self allColumnValuesWithColumnName collect: [ :columnAssoc |
-		self plotHistogram: columnAssoc ].
+		          self plotHistogram: columnAssoc ].
 
 	aCanvas
 		addAll: shapes;
 		addInteraction: RSCanvasController new.
 
-	aCanvas when: RSExtentChangedEvent do: [
-		RSFlowLayout new
-			gapSize: 10;
-			maxWidth: aCanvas extent x;
-			on: shapes.
-		aCanvas camera zoomToFit: aCanvas extent * 0.98.
+	aCanvas
+		when: RSExtentChangedEvent
+		do: [
+			RSFlowLayout new
+				gapSize: 10;
+				maxWidth: aCanvas extent x;
+				on: shapes.
+			aCanvas camera zoomToFit: aCanvas extent * 0.98.
 
-		aCanvas signalUpdate ]
+			aCanvas signalUpdate ]
+		for: self
 ]
 
 { #category : #initialization }

--- a/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
@@ -117,24 +117,27 @@ AISpDataFrameDescriberPresenter >> initializeDataFramePresenter [
 
 	self initializeDataFramePresenterContents.
 
-	dataFramePresenter items: dataFrame
+	dataFramePresenter items: dataFrame asArrayOfRowsWithName
 ]
 
 { #category : #initialization }
 AISpDataFrameDescriberPresenter >> initializeDataFramePresenterContents [
 	" Private - Set the receiver's displayed contents. Display row names if present "
 
-	dataFramePresenter addColumn: self newCheckBoxColumn.
-	
-	{ nil } , dataFrame columnNames doWithIndex: [ : columnName :idx |
-		| evalBlock |
-		evalBlock := columnName
-			ifNil: [ [ : selection | selection name ] ]
-			ifNotNil: [ [ : selection | selection dataSeriesElementAt: idx - 1 ] ].
+	dataFramePresenter 
+		addColumn: self newIndexColumn;
+		addColumn: self newCheckBoxColumn;
+		addColumn: self newRowNamesColumn.
+
+	dataFrame columnNames doWithIndex: [ : columnName :idx |
 		dataFramePresenter addColumn: (SpStringTableColumn new
-				 title: columnName;
-				 beSortable;
-				 evaluated: evalBlock ) ].
+			title: columnName;
+			compareFunction: [ : colA : colB | 
+				(colA at: (dataFrame indexOfColumnNamed: columnName) + 1) <=
+					(colB at: (dataFrame indexOfColumnNamed: columnName) + 1) ];			
+			evaluated: [ : selection | selection dataSeriesElementAt: idx + 1 ] ) ].
+			
+
 ]
 
 { #category : #initialization }
@@ -180,6 +183,26 @@ AISpDataFrameDescriberPresenter >> newCheckBoxColumn [
 			onDeactivation: [ :branch | self selectedItems remove: branch ];
 			width: 20 * self currentWorld displayScaleFactor;
 			yourself
+]
+
+{ #category : #initialization }
+AISpDataFrameDescriberPresenter >> newIndexColumn [
+
+	^ SpIndexTableColumn new
+		title: '#';
+		width: 30;
+		beNotExpandable;
+		yourself
+
+]
+
+{ #category : #initialization }
+AISpDataFrameDescriberPresenter >> newRowNamesColumn [
+
+	^ SpStringTableColumn new
+			title: 'Row Name';
+			compareFunction: [ : colA : colB | colA asString threeWayCompareTo: colB asString ];
+			evaluated: [ : rowWithName | rowWithName at: 1 ]
 ]
 
 { #category : #accessing }

--- a/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
@@ -201,7 +201,7 @@ AISpDataFrameDescriberPresenter >> newRowNamesColumn [
 
 	^ SpStringTableColumn new
 			title: 'Row Name';
-			compareFunction: [ : colA : colB | colA asString threeWayCompareTo: colB asString ];
+			compareFunction: [ : objA : objB | objA asString < objB asString ];
 			evaluated: [ : rowWithName | rowWithName at: 1 ]
 ]
 

--- a/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpDataFrameDescriberPresenter.class.st
@@ -1,6 +1,13 @@
 "
+## Description
+
+Provide a Spec Presenter to display a data frame detailed description of its contents and basic statistics.
+
+## Examples
+```language=Pharo
 AISpDataFrameInspector openOn: AIDatasets loadIris.
 AISpDataFrameInspector openOn: AIDatasets loadWine.
+```
 "
 Class {
 	#name : #AISpDataFrameDescriberPresenter,
@@ -108,15 +115,26 @@ AISpDataFrameDescriberPresenter >> initializeDataFramePresenter [
 		contextMenu: [ self contextMenu ];
 		contextKeyBindings: self contextMenuKeyBindings.
 
-	dataFramePresenter addColumn: self newCheckBoxColumn.
+	self initializeDataFramePresenterContents.
 
-	dataFrame columnNames doWithIndex: [ :columnName :idx |
+	dataFramePresenter items: dataFrame
+]
+
+{ #category : #initialization }
+AISpDataFrameDescriberPresenter >> initializeDataFramePresenterContents [
+	" Private - Set the receiver's displayed contents. Display row names if present "
+
+	dataFramePresenter addColumn: self newCheckBoxColumn.
+	
+	{ nil } , dataFrame columnNames doWithIndex: [ : columnName :idx |
+		| evalBlock |
+		evalBlock := columnName
+			ifNil: [ [ : selection | selection name ] ]
+			ifNotNil: [ [ : selection | selection dataSeriesElementAt: idx - 1 ] ].
 		dataFramePresenter addColumn: (SpStringTableColumn new
 				 title: columnName;
 				 beSortable;
-				 evaluated: [ : selection | selection dataSeriesElementAt: idx ]) ].
-
-	dataFramePresenter items: dataFrame
+				 evaluated: evalBlock ) ].
 ]
 
 { #category : #initialization }

--- a/src/AI-DataFrameInspector/AISpScatterMatrixPresenter.class.st
+++ b/src/AI-DataFrameInspector/AISpScatterMatrixPresenter.class.st
@@ -41,7 +41,8 @@ AISpScatterMatrixPresenter >> initializeScatterMatrix: aCanvas [
 
 	| shapes namedColumns |
 	shapes := OrderedCollection new.
-	namedColumns := (model numericColumnNames collect: [ :e | e -> (model column: e) ]) asOrderedDictionary.
+	namedColumns := (model numericColumnNames collect: [ :e |
+		                 e -> (model column: e) ]) asOrderedDictionary.
 	namedColumns keys doWithIndex: [ :column1 :index1 |
 		namedColumns keys doWithIndex: [ :column2 :index2 |
 			| container c plot |
@@ -53,7 +54,10 @@ AISpScatterMatrixPresenter >> initializeScatterMatrix: aCanvas [
 					        RSHistogramPlot new
 						        x: (namedColumns at: column1);
 						        numberOfBins: 50 ]
-				        ifFalse: [ RSScatterPlot new x: (namedColumns at: column2) values y: (namedColumns at: column1) values ].
+				        ifFalse: [
+					        RSScatterPlot new
+						        x: (namedColumns at: column2) values
+						        y: (namedColumns at: column1) values ].
 
 
 			c container: container.
@@ -83,11 +87,14 @@ AISpScatterMatrixPresenter >> initializeScatterMatrix: aCanvas [
 		addAll: shapes;
 		addInteraction: RSCanvasController new.
 
-	aCanvas when: RSExtentChangedEvent do: [
-		RSGridLayout on: shapes.
-		aCanvas camera zoomToFit: aCanvas extent * 0.98.
+	aCanvas
+		when: RSExtentChangedEvent
+		do: [
+			RSGridLayout on: shapes.
+			aCanvas camera zoomToFit: aCanvas extent * 0.98.
 
-		aCanvas signalUpdate ]
+			aCanvas signalUpdate ]
+		for: self
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Add two columns to Data Description tab:

- One column display the index of each row.
- Another column display the row name, if set, of each row.
- Keep the sortable feature of columns.

Examples:

Setting the row names:
```smalltalk
| df |
classes := SystemNavigation new allClasses.
df := DataFrame withRowNames: classes. 
evalBlocks := { 
	'Methods' -> [ : c | c methods size ] .
	'Lines of Code' -> [ : c | c methods sum: #linesOfCode ] }.
evalBlocks associationsDo: [ : evalAssoc |
df 
	addColumn: (classes collect: evalAssoc value)
	named: evalAssoc key ].
df.
```

Without setting the row names:
```smalltalk
| df |
classes := SystemNavigation new allClasses collect: [ : c | 
	{ 
		(c methods size) . 
		(c methods sum: #linesOfCode)
	} ].
df := DataFrame withColumnNames: { 'Methods' . 'Lines of Code' }.
df initializeRows: classes.
``` 
